### PR TITLE
Add 32-bit and double-precision FPU support for hpmicro series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cache/
+build/
+.vscode/

--- a/asm/jump_riscv32_elf_gas.S
+++ b/asm/jump_riscv32_elf_gas.S
@@ -1,111 +1,219 @@
-/*
-   Distributed under the Boost Software License, Version 1.0.
-      (See accompanying file LICENSE_1_0.txt or copy at
-          http://www.boost.org/LICENSE_1_0.txt)
-*/
+  /*
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+  */
 
 
-.file "jump_riscv64_elf_gas.S"
-.text
-.align  1
-.global jump_fcontext
-.type   jump_fcontext, %function
+  .file "jump_riscv32_elf_gas.S"
+  .text
+  .align  1
+  .global jump_fcontext
+  .type   jump_fcontext, %function
 jump_fcontext:
-#ifdef __riscv_flen
-    # prepare stack for GP + FPU
-    addi  sp, sp, -0x68
 
-    # save fs0 - fs11
-    fsw  f0, 0x38(sp)
-    fsw  f1, 0x3c(sp)
-    fsw  f2, 0x40(sp)
-    fsw  f3, 0x44(sp)
-    fsw  f4, 0x48(sp)
-    fsw  f5, 0x4c(sp)
-    fsw  f6, 0x50(sp)
-    fsw  f7, 0x54(sp)
-    fsw  f8, 0x58(sp)
-    fsw  f9, 0x5c(sp)
-    fsw  f10, 0x60(sp)
-    fsw  f11, 0x64(sp)
+  #if __riscv_xlen == 64
+  .set GP_REGSIZE, 8
+  #else
+  .set GP_REGSIZE, 4
+  #endif
 
-#else
-    # prepare stack for GP
-    addi  sp, sp, -0x38
-#endif
+  # GP共14个条目: s0-s11(12), ra(1), pc(1)
+  .set GP_COUNT, 14
+  .set GP_SIZE, GP_COUNT * GP_REGSIZE
 
-    # save s0-s11, ra
-    sw  s0, 0x00(sp)
-    sw  s1, 0x04(sp)
-    sw  s2, 0x08(sp)
-    sw  s3, 0x0c(sp)
-    sw  s4, 0x10(sp)
-    sw  s5, 0x14(sp)
-    sw  s6, 0x18(sp)
-    sw  s7, 0x1c(sp)
-    sw  s8, 0x20(sp)
-    sw  s9, 0x24(sp)
-    sw  s10, 0x28(sp)
-    sw  s11, 0x2c(sp)
-    
-    sw  ra, 0x30(sp)
+  #ifdef __riscv_flen
+  #if __riscv_flen == 64
+  .set FP_REGSIZE, 8
+  #else
+  .set FP_REGSIZE, 4
+  #endif
+  .set FP_COUNT, 12
+  .set FP_SIZE, FP_COUNT * FP_REGSIZE
+  .set STACK_SIZE, GP_SIZE + FP_SIZE
+  #else
+  .set STACK_SIZE, GP_SIZE
+  #endif
 
-    # save RA as PC
-    sw  ra, 0x34(sp)
+  # 寄存器偏移定义(GP)
+  .set OFF_s0,     0 * GP_REGSIZE
+  .set OFF_s1,     1 * GP_REGSIZE
+  .set OFF_s2,     2 * GP_REGSIZE
+  .set OFF_s3,     3 * GP_REGSIZE
+  .set OFF_s4,     4 * GP_REGSIZE
+  .set OFF_s5,     5 * GP_REGSIZE
+  .set OFF_s6,     6 * GP_REGSIZE
+  .set OFF_s7,     7 * GP_REGSIZE
+  .set OFF_s8,     8 * GP_REGSIZE
+  .set OFF_s9,     9 * GP_REGSIZE
+  .set OFF_s10,   10 * GP_REGSIZE
+  .set OFF_s11,   11 * GP_REGSIZE
+  .set OFF_ra,    12 * GP_REGSIZE
+  .set OFF_pc,    13 * GP_REGSIZE
 
-    # store SP (pointing to context-data) in A2
-    mv  a2, sp
+  #ifdef __riscv_flen
+  # FPU寄存器偏移，从GP_SIZE开始
+  .set OFF_fs0,   GP_SIZE + (0  * FP_REGSIZE)
+  .set OFF_fs1,   GP_SIZE + (1  * FP_REGSIZE)
+  .set OFF_fs2,   GP_SIZE + (2  * FP_REGSIZE)
+  .set OFF_fs3,   GP_SIZE + (3  * FP_REGSIZE)
+  .set OFF_fs4,   GP_SIZE + (4  * FP_REGSIZE)
+  .set OFF_fs5,   GP_SIZE + (5  * FP_REGSIZE)
+  .set OFF_fs6,   GP_SIZE + (6  * FP_REGSIZE)
+  .set OFF_fs7,   GP_SIZE + (7  * FP_REGSIZE)
+  .set OFF_fs8,   GP_SIZE + (8  * FP_REGSIZE)
+  .set OFF_fs9,   GP_SIZE + (9  * FP_REGSIZE)
+  .set OFF_fs10,  GP_SIZE + (10 * FP_REGSIZE)
+  .set OFF_fs11,  GP_SIZE + (11 * FP_REGSIZE)
+  #endif
 
-    # restore SP (pointing to context-data) from A0
-    mv  sp, a0
+  # 调整栈指针
+  addi sp, sp, -STACK_SIZE
 
-#ifdef __riscv_flen
-    # load fs0 - fs11
-    flw  f0, 0x38(sp)
-    flw  f1, 0x3c(sp)
-    flw  f2, 0x40(sp)
-    flw  f3, 0x44(sp)
-    flw  f4, 0x48(sp)
-    flw  f5, 0x4c(sp)
-    flw  f6, 0x50(sp)
-    flw  f7, 0x54(sp)
-    flw  f8, 0x58(sp)
-    flw  f9, 0x5c(sp)
-    flw  f10, 0x60(sp)
-    flw  f11, 0x64(sp)
-#endif
-    
-    # load s0-s11,ra
-    lw  s0, 0x00(sp)
-    lw  s1, 0x04(sp)
-    lw  s2, 0x08(sp)
-    lw  s3, 0x0c(sp)
-    lw  s4, 0x10(sp)
-    lw  s5, 0x14(sp)
-    lw  s6, 0x18(sp)
-    lw  s7, 0x1c(sp)
-    lw  s8, 0x20(sp)
-    lw  s9, 0x24(sp)
-    lw  s10, 0x28(sp)
-    lw  s11, 0x2c(sp)
-    lw  ra, 0x30(sp)
+  # 保存GP寄存器
+  #if __riscv_xlen == 64
+  sd s0,  OFF_s0(sp)
+  sd s1,  OFF_s1(sp)
+  sd s2,  OFF_s2(sp)
+  sd s3,  OFF_s3(sp)
+  sd s4,  OFF_s4(sp)
+  sd s5,  OFF_s5(sp)
+  sd s6,  OFF_s6(sp)
+  sd s7,  OFF_s7(sp)
+  sd s8,  OFF_s8(sp)
+  sd s9,  OFF_s9(sp)
+  sd s10, OFF_s10(sp)
+  sd s11, OFF_s11(sp)
+  sd ra,  OFF_ra(sp)
+  sd ra,  OFF_pc(sp)  # pc位置存ra以备后续跳转
+  #else
+  sw s0,  OFF_s0(sp)
+  sw s1,  OFF_s1(sp)
+  sw s2,  OFF_s2(sp)
+  sw s3,  OFF_s3(sp)
+  sw s4,  OFF_s4(sp)
+  sw s5,  OFF_s5(sp)
+  sw s6,  OFF_s6(sp)
+  sw s7,  OFF_s7(sp)
+  sw s8,  OFF_s8(sp)
+  sw s9,  OFF_s9(sp)
+  sw s10, OFF_s10(sp)
+  sw s11, OFF_s11(sp)
+  sw ra,  OFF_ra(sp)
+  sw ra,  OFF_pc(sp)   # pc位置存ra
+  #endif
 
-    # return transfer_t from jump
-    # pass transfer_t as first arg in context function
-    # a0 == FCTX, a1 == DATA
-    mv a0, a2
+  # a2存储当前上下文指针
+  mv a2, sp
 
-    # load pc
-    lw  a2, 0x34(sp)
+  # sp 指向A0给出的新上下文
+  mv sp, a0
 
-    # restore stack from GP + FPU
-#ifdef __riscv_flen
-    addi  sp, sp, 0x68
-#else
-    addi  sp, sp, 0x38
-#endif
+  #ifdef __riscv_flen
+  # 保存FPU寄存器
+  #if __riscv_flen == 64
+  fsd fs0,  OFF_fs0(a2)
+  fsd fs1,  OFF_fs1(a2)
+  fsd fs2,  OFF_fs2(a2)
+  fsd fs3,  OFF_fs3(a2)
+  fsd fs4,  OFF_fs4(a2)
+  fsd fs5,  OFF_fs5(a2)
+  fsd fs6,  OFF_fs6(a2)
+  fsd fs7,  OFF_fs7(a2)
+  fsd fs8,  OFF_fs8(a2)
+  fsd fs9,  OFF_fs9(a2)
+  fsd fs10, OFF_fs10(a2)
+  fsd fs11, OFF_fs11(a2)
 
-    jr a2
-.size   jump_fcontext,.-jump_fcontext
-# Mark that we don't need executable stack.
-.section .note.GNU-stack,"",%progbits
+  # 恢复新上下文的FPU寄存器
+  fld fs0,  OFF_fs0(sp)
+  fld fs1,  OFF_fs1(sp)
+  fld fs2,  OFF_fs2(sp)
+  fld fs3,  OFF_fs3(sp)
+  fld fs4,  OFF_fs4(sp)
+  fld fs5,  OFF_fs5(sp)
+  fld fs6,  OFF_fs6(sp)
+  fld fs7,  OFF_fs7(sp)
+  fld fs8,  OFF_fs8(sp)
+  fld fs9,  OFF_fs9(sp)
+  fld fs10, OFF_fs10(sp)
+  fld fs11, OFF_fs11(sp)
+  #else
+  fsw fs0,  OFF_fs0(a2)
+  fsw fs1,  OFF_fs1(a2)
+  fsw fs2,  OFF_fs2(a2)
+  fsw fs3,  OFF_fs3(a2)
+  fsw fs4,  OFF_fs4(a2)
+  fsw fs5,  OFF_fs5(a2)
+  fsw fs6,  OFF_fs6(a2)
+  fsw fs7,  OFF_fs7(a2)
+  fsw fs8,  OFF_fs8(a2)
+  fsw fs9,  OFF_fs9(a2)
+  fsw fs10, OFF_fs10(a2)
+  fsw fs11, OFF_fs11(a2)
+
+  # 恢复新上下文的FPU寄存器
+  flw fs0,  OFF_fs0(sp)
+  flw fs1,  OFF_fs1(sp)
+  flw fs2,  OFF_fs2(sp)
+  flw fs3,  OFF_fs3(sp)
+  flw fs4,  OFF_fs4(sp)
+  flw fs5,  OFF_fs5(sp)
+  flw fs6,  OFF_fs6(sp)
+  flw fs7,  OFF_fs7(sp)
+  flw fs8,  OFF_fs8(sp)
+  flw fs9,  OFF_fs9(sp)
+  flw fs10, OFF_fs10(sp)
+  flw fs11, OFF_fs11(sp)
+  #endif
+  #endif
+
+  # 恢复GP寄存器
+  #if __riscv_xlen == 64
+  ld s0,  OFF_s0(sp)
+  ld s1,  OFF_s1(sp)
+  ld s2,  OFF_s2(sp)
+  ld s3,  OFF_s3(sp)
+  ld s4,  OFF_s4(sp)
+  ld s5,  OFF_s5(sp)
+  ld s6,  OFF_s6(sp)
+  ld s7,  OFF_s7(sp)
+  ld s8,  OFF_s8(sp)
+  ld s9,  OFF_s9(sp)
+  ld s10, OFF_s10(sp)
+  ld s11, OFF_s11(sp)
+  ld ra,  OFF_ra(sp)
+  #else
+  lw s0,  OFF_s0(sp)
+  lw s1,  OFF_s1(sp)
+  lw s2,  OFF_s2(sp)
+  lw s3,  OFF_s3(sp)
+  lw s4,  OFF_s4(sp)
+  lw s5,  OFF_s5(sp)
+  lw s6,  OFF_s6(sp)
+  lw s7,  OFF_s7(sp)
+  lw s8,  OFF_s8(sp)
+  lw s9,  OFF_s9(sp)
+  lw s10, OFF_s10(sp)
+  lw s11, OFF_s11(sp)
+  lw ra,  OFF_ra(sp)
+  #endif
+
+  # 返回参数 a0 指向旧上下文，a1保留使用者处理
+  mv a0, a2
+
+  # load pc
+  #if __riscv_xlen == 64
+  ld  a2, OFF_pc(sp)
+  #else
+  lw a2,  OFF_pc(sp)
+  #endif
+
+  # 恢复栈指针
+  addi sp, sp, STACK_SIZE
+
+  jr a2
+  .size jump_fcontext, .-jump_fcontext
+
+  .section .note.GNU-stack,"",%progbits
+

--- a/asm/make_riscv32_elf_gas.S
+++ b/asm/make_riscv32_elf_gas.S
@@ -1,42 +1,86 @@
-/*
-   Distributed under the Boost Software License, Version 1.0.
-      (See accompanying file LICENSE_1_0.txt or copy at
-          http://www.boost.org/LICENSE_1_0.txt)
-*/
+  /*
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+  */
 
-.file "make_riscv64_elf_gas.S"
-.text
-.align  1
-.global make_fcontext
-.type   make_fcontext, %function
+  .file "make_riscv32_elf_gas.S"
+  .text
+  .align  1
+  .global make_fcontext
+  .type   make_fcontext, %function
 make_fcontext:
-    # shift address in a0 (allocated stack) to lower 4 byte boundary
-    andi a0, a0, ~0x3
 
-    # reserve space for context-data on context-stack
-#ifdef __riscv_flen
-    addi  a0, a0, -0x68
-#else
-    addi  a0, a0, -0x38
-#endif
+  #if __riscv_xlen == 64
+  .set GP_REGSIZE, 8
+  #else
+  .set GP_REGSIZE, 4
+  #endif
 
-    # third arg of make_fcontext() == address of context-function
-    # store address as a PC to jump in
-    sw  a2, 0x34(a0)
+  # GP寄存器数量：s0-s11(12个) + ra(1个) + pc(1个) = 14个
+  .set GP_COUNT, 14
+  .set GP_SIZE, GP_COUNT * GP_REGSIZE
 
-    # save address of finish as return-address for context-function
-    # will be entered after context-function returns (RA register)
-    lla  a4, finish
-    sw  a4, 0x30(a0)
+  #ifdef __riscv_flen
+  #if __riscv_flen == 64
+  .set FP_REGSIZE, 8
+  #else
+  .set FP_REGSIZE, 4
+  #endif
+  .set FP_COUNT, 12
+  .set FP_SIZE, FP_COUNT * FP_REGSIZE
+  .set STACK_SIZE, GP_SIZE + FP_SIZE
+  #else
+  .set STACK_SIZE, GP_SIZE
+  #endif
 
-    ret // return pointer to context-data (a0)
+  # 定义GP寄存器偏移
+  .set OFF_s0,    0 * GP_REGSIZE
+  .set OFF_s1,    1 * GP_REGSIZE
+  .set OFF_s2,    2 * GP_REGSIZE
+  .set OFF_s3,    3 * GP_REGSIZE
+  .set OFF_s4,    4 * GP_REGSIZE
+  .set OFF_s5,    5 * GP_REGSIZE
+  .set OFF_s6,    6 * GP_REGSIZE
+  .set OFF_s7,    7 * GP_REGSIZE
+  .set OFF_s8,    8 * GP_REGSIZE
+  .set OFF_s9,    9 * GP_REGSIZE
+  .set OFF_s10,  10 * GP_REGSIZE
+  .set OFF_s11,  11 * GP_REGSIZE
+  .set OFF_ra,   12 * GP_REGSIZE
+  .set OFF_pc,   13 * GP_REGSIZE
+
+  # 对齐a0到4字节边界（与原代码保持一致）
+  andi a0, a0, ~0x3
+
+  # 为上下文数据保留空间（STACK_SIZE根据上面条件计算）
+  addi a0, a0, -STACK_SIZE
+
+  # a2是第三个参数：context-function的地址
+  # 将其存为要跳转的PC
+  #if __riscv_xlen == 64
+  sd a2, OFF_pc(a0)
+  #else
+  sw a2, OFF_pc(a0)
+  #endif
+
+  # 保存finish作为返回地址（RA寄存器初始值）
+  lla a4, finish
+  #if __riscv_xlen == 64
+  sd a4, OFF_ra(a0)
+  #else
+  sw a4, OFF_ra(a0)
+  #endif
+
+  # 返回a0作为context-data指针
+  ret
 
 finish:
-    # exit code is zero
-    li  a0, 0
-    # exit application
-    tail  _exit@plt
+  # 结束时返回码0
+  li  a0, 0
+  # 调用_exit结束程序
+  tail _exit@plt
 
-.size   make_fcontext,.-make_fcontext
-# Mark that we don't need executable stack.
-.section .note.GNU-stack,"",%progbits
+  .size   make_fcontext,.-make_fcontext
+  .section .note.GNU-stack,"",%progbits
+

--- a/include/s_port_hpmicro.h
+++ b/include/s_port_hpmicro.h
@@ -1,0 +1,11 @@
+#ifndef INC_S_PORT_H_
+#define INC_S_PORT_H_
+
+/* 2. define the clock ticks count for one second */
+#define MY_CLOCKS_PER_SEC (24000000)
+
+extern uint64_t get_timer_value(void);
+
+#include "s_port_riscv.h"
+
+#endif

--- a/include/s_port_riscv.h
+++ b/include/s_port_riscv.h
@@ -20,7 +20,9 @@ typedef uint64_t my_clock_t;
 typedef int64_t my_clock_diff_t;
 
 /* 2. define the clock ticks count for one second */
-#define MY_CLOCKS_PER_SEC (SystemCoreClock/4)
+#ifndef MY_CLOCKS_PER_SEC
+#define MY_CLOCKS_PER_SEC 24000000
+#endif
 
 /* 3. Implement the initilization function for clock. Leave it blank if not required. */
 void my_clock_init(void);

--- a/include/s_task.h
+++ b/include/s_task.h
@@ -86,10 +86,17 @@ typedef void(*s_task_fn_t)(__async__, void *arg);
 #   define USE_LIST_TIMER_CONTAINER
 #   include "s_port_avr.h"
 #elif defined __riscv
-#   define USE_IN_EMBEDDED
-#   define USE_JUMP_FCONTEXT
-#   define USE_LIST_TIMER_CONTAINER
-#   include "s_port_gd32vf103.h"
+#   if defined HPMICRO
+#       define USE_IN_EMBEDDED
+#       define USE_JUMP_FCONTEXT
+#       define USE_LIST_TIMER_CONTAINER
+#       include "s_port_hpmicro.h"
+#   else
+#       define USE_IN_EMBEDDED
+#       define USE_JUMP_FCONTEXT
+#       define USE_LIST_TIMER_CONTAINER
+#       include "s_port_gd32vf103.h"
+#   endif
 #else
 #   error "no arch detected"
 #endif

--- a/projects/hpmicro/CMakeLists.txt
+++ b/projects/hpmicro/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 HPMicro
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.13)
+
+if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+    SET(CMAKE_BUILD_TYPE flash_xip)
+endif()
+
+set(CONFIG_SEGGER_RTT 1)
+set(CONFIG_NDEBUG_CONSOLE 1)
+
+set(APP_NAME "test_app")
+
+add_definitions(-DBOARD_SHOW_CLOCK=0 -DBOARD_SHOW_BANNER=0 -DCONFIG_NDEBUG_CONSOLE -DCONSOLE_TYPE_UART=0)
+add_compile_options(-g -gdwarf-2)
+
+find_package(hpm-sdk REQUIRED HINTS $ENV{HPM_SDK_BASE})
+
+project(app)
+
+sdk_compile_definitions(-DUSB_HOST_MCU_CORE=HPM_CORE0)
+
+add_definitions(-DHPMICRO)
+add_subdirectory(s_task)
+
+sdk_inc(src)
+sdk_inc(s_task/include)
+
+sdk_app_src(main.c)
+
+target_link_libraries(app PRIVATE s_task)

--- a/projects/hpmicro/build_linux.sh
+++ b/projects/hpmicro/build_linux.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p "./build"
+cd "./build"
+cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE=flash_xip -DBOARD=hpm6200evk ..
+ninja

--- a/projects/hpmicro/main.c
+++ b/projects/hpmicro/main.c
@@ -1,0 +1,73 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "board.h"
+#include "hpm_common.h"
+#include "s_task.h"
+
+volatile bool g_is_low = false;
+volatile bool g_exit   = false;
+
+void sub_task_fast_blinking(__async__, void *arg)
+{
+    (void)arg;
+    while (!g_exit)
+    {
+        s_task_msleep(__await__, 50); /* wait for 50 milliseconds */
+        s_task_msleep(__await__, 50); /* wait for 50 milliseconds */
+    }
+}
+void sub_task_fast_blinking1(__async__, void *arg)
+{
+    (void)arg;
+    while (!g_exit)
+    {
+        s_task_msleep(__await__, 150); /* wait for 50 milliseconds */
+        s_task_msleep(__await__, 150); /* wait for 50 milliseconds */
+    }
+}
+
+ATTR_PLACE_AT_FAST_RAM_INIT uint32_t g_stack0[1024] = {0};
+ATTR_PLACE_AT_FAST_RAM_INIT uint32_t g_stack1[1024] = {0};
+
+void main_task(__async__, void *arg)
+{
+    (void)arg;
+
+
+    /* create two sub tasks */
+    s_task_create(g_stack0, sizeof(g_stack0), sub_task_fast_blinking, NULL);
+    s_task_create(g_stack1, sizeof(g_stack1), sub_task_fast_blinking1, NULL);
+
+    /* wait for 10 seconds */
+    s_task_sleep(__await__, 10);
+
+    g_exit = true;
+
+    /* wait two sub tasks return */
+    s_task_join(__await__, g_stack0);
+    s_task_join(__await__, g_stack1);
+}
+
+ATTR_PLACE_AT_FAST_RAM_INIT void* g_stack_main[1024];
+
+uint64_t get_timer_value(void)
+{
+    return HPM_MCHTMR->MTIME;
+}
+
+int main(void)
+{
+    board_init();
+
+    board_delay_ms(50);
+
+    s_task_init_system();
+
+    s_task_create(g_stack_main, sizeof(g_stack_main), main_task, NULL);
+    s_task_join(__await__, g_stack_main);
+
+    while (1)
+    {
+    };
+}

--- a/src/s_port_hpmicro.inc.h
+++ b/src/s_port_hpmicro.inc.h
@@ -1,0 +1,40 @@
+/* Timer functions need to be implemented on a new porting. */
+
+void my_clock_init(){
+    // Don't start measuruing until we see an mtime tick
+    uint64_t start_mtime;
+    uint64_t tmp = get_timer_value();
+    do {
+        start_mtime = get_timer_value();
+    } while (start_mtime == tmp);
+}
+
+my_clock_t my_clock() {
+    return get_timer_value();
+}
+
+void my_on_idle(uint64_t max_idle_ms) {
+    uint64_t start_mtime, delta_mtime;
+
+    start_mtime = get_timer_value();
+
+    do {
+        delta_mtime = get_timer_value() - start_mtime;
+    } while(
+        !g_globals.irq_actived
+        && delta_mtime < (MY_CLOCKS_PER_SEC * max_idle_ms / 1000));
+}
+
+
+
+#ifdef USE_JUMP_FCONTEXT
+extern
+transfer_t jump_fcontext( fcontext_t const to, void * vp);
+extern
+fcontext_t make_fcontext( void * sp, size_t size, void (* fn)( transfer_t) );
+
+void create_fcontext(fcontext_t *fc, void *stack, size_t stack_size, void (* fn)( transfer_t)) {
+    stack = (void *)((char *)stack + stack_size);
+    *fc = make_fcontext(stack, stack_size, fn);
+}
+#endif

--- a/src/s_task.c
+++ b/src/s_task.c
@@ -53,7 +53,11 @@ THREAD_LOCAL s_task_globals_t g_globals;
 #elif defined __AVR__
 #   include "s_port_avr.inc.h"
 #elif defined __riscv
-#   include "s_port_gd32vf103.inc.h"
+#   if defined HPMICRO
+#       include "s_port_hpmicro.inc.h"
+#   else
+#       include "s_port_gd32vf103.inc.h"
+#   endif
 #else
 #   error "no arch detected"
 #endif


### PR DESCRIPTION
Refactor RISC-V assembly to support 32-bit mode and double-precision FPU features for the hpmicro(Ander D45) chips, and validate these changes on both the hpm6200evk and hpm6e00evk evaluation boards.